### PR TITLE
fix link to original project repo on bitbucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ mgs-canopy-algorithm
 Fork of the *canopy clustering algorithm* implementation published by [Nielsen et al.](http://www.nature.com/nbt/journal/v32/n8/full/nbt.2939.html)
 It is faster and uses less memory.
 
-For more information, consult [the original project repository](http://git.dworzynski.eu/mgs-canopy-algorithm/wiki/Home)
+For more information, consult [the original project repository](https://bitbucket.org/HeyHo/mgs-canopy-algorithm/wiki/Home)


### PR DESCRIPTION
The forward through Piotr's home page no longer works.
